### PR TITLE
Change default view option of leaderboard and config panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,8 +58,8 @@ function App() {
     icon: "./bot4.gif",
   });
 
-  const [showLeaderboard, setShowLeaderboard] = useState(false);
-  const [showPanel, setShowPanel] = useState(false); 
+  const [showLeaderboard, setShowLeaderboard] = useState(true);
+  const [showPanel, setShowPanel] = useState(true); 
 
   return (
     <div className="App">


### PR DESCRIPTION
Changed the default view option of config panel and leaderboard. When user load the game all components should be visible as per game instruction. So, user don't have to open config panel first then enter value instead we should give option as we see in most applications. After game starts user can close both panels. 